### PR TITLE
For large source maps, enable sending request body of any size

### DIFF
--- a/src/common/rollbar-api.js
+++ b/src/common/rollbar-api.js
@@ -13,6 +13,9 @@ class RollbarAPI {
       // Always resolve, regardless of status code.
       // When we let axios reject, we end up with less specific error messages.
       validateStatus: function (_status) { return true; },
+      // Let axios send anything, and let the API decide what the max length should be.
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
     });
   }
 


### PR DESCRIPTION
## Description of the change

Axios has a default limit for request body size (10MB I think), and this prevents sending larger source maps. This PR allows Axios to send any size, and the API can return the appropriate error if the upload is too big.

No new tests are added, as Axios is stubbed and these flags would not be directly exercised.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> ch73107

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 