### PR TITLE
chore: fix readme preview in npmjs search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # rollbar-cli
 
-![build](https://github.com/rollbar/rollbar-cli/workflows/Node.js%20CI/badge.svg)
-
 The Rollbar CLI provides easy command line access to Rollbar's API features,
 starting with source map uploads and notifying deploys.
+
+![build](https://github.com/rollbar/rollbar-cli/workflows/Node.js%20CI/badge.svg)
 
 ## Install
 
@@ -54,7 +54,7 @@ and it must exactly match the URLs in the error stack frames. See `minified_url`
 error payload, which is usually set in the config options for Rollbar.js.
 See [Source Maps](https://docs.rollbar.com/docs/source-maps) for more information.
 
-`--next`: This is an optional parameter triggering next version. When specified, all source map files 
+`--next`: This is an optional parameter triggering next version. When specified, all source map files
 are compressed and uploaded as one zip file directly.
 
 Example:


### PR DESCRIPTION
## Description of the change

The summary text in npmjs search results shows the raw code for the CI badge, since it takes the first non-heading text from the readme. This PR puts the badge below the summary text.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore

## Related issues

ch86782

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 