### PR TITLE
feat: discover sourcemaps local to source

### DIFF
--- a/src/sourcemaps/scanner.js
+++ b/src/sourcemaps/scanner.js
@@ -37,17 +37,27 @@ class Scanner {
   }
 
   extractMapPath(file) {
+    // check sourceMappingURL to see if a map is defined
     const mapPath = this.parseMapPath(file.filePathName);
-
-    if(mapPath) {
+    if (mapPath) {
       output.status('', mapPath);
       file.mapPathName = mapPath;
       file.sourceMappingURL = true;
       file.mappedFile = path.join(this.targetPath, mapPath);
-
-    } else {
-      output.warn('', 'map not found');
+      return;
     }
+
+    // check to see if the file exists locally
+    const localPath = this.localMapPath(file.filePathName);
+    if (localPath) {
+      output.status('', localPath);
+      file.mapPathName = localPath;
+      file.sourceMappingURL = false;
+      file.mappedFile = path.join(this.targetPath, localPath);
+      return;
+    }
+
+    output.warn('', 'map not found');
   }
 
   async loadMapData(file) {
@@ -189,6 +199,12 @@ class Scanner {
         return matched[1];
       }
     }
+  }
+
+  localMapPath(sourcePath) {
+    const mapPath = sourcePath + '.map';
+    const stat = fs.statSync(mapPath, { throwIfNoEntry: false });
+    return stat && stat.isFile() ? path.basename(mapPath) : undefined;
   }
 }
 


### PR DESCRIPTION
## Description of the change

In addition to parsing the `sourceMappingURL`, this PR allows for the discovery of local maps. This useful in situations where maps exist during deployment, but not in production (i.e. when sources are build with maps but without a `sourceMappingURL` line)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
